### PR TITLE
Run $(...).tooltip() on each element as it's added

### DIFF
--- a/src/Hubbup.IssueMoverClient/Pages/FatalErrorEntry.cshtml
+++ b/src/Hubbup.IssueMoverClient/Pages/FatalErrorEntry.cshtml
@@ -1,13 +1,11 @@
 ﻿@using Hubbup.IssueMover.Dto
 
-<span data-toggle="tooltip" data-placement="left" title="@ErrorMessage">@Description</span>
+<span ref="tooltipElem" data-toggle="tooltip" data-placement="left" title="@ErrorMessage">@Description</span>
 <span class="glyphicon glyphicon-remove" style="color: red" aria-hidden="true"></span>
 
-@{
-    ((IJSInProcessRuntime)JSRuntime.Current).Invoke<object>("updateTooltips");
-}
-
 @functions {
+    ElementRef tooltipElem;
+
     [Parameter]
     private string Description { get; set; }
 
@@ -28,5 +26,10 @@
             }
             return ErrorResult.Exception?.Message;
         }
+    }
+
+    protected override async Task OnAfterRenderAsync()
+    {
+        await JSRuntime.Current.InvokeAsync<object>("updateTooltips", tooltipElem);
     }
 }

--- a/src/Hubbup.Web/Pages/Mover.cshtml
+++ b/src/Hubbup.Web/Pages/Mover.cshtml
@@ -9,7 +9,7 @@
 <script src="_framework/blazor.webassembly.js"></script>
 
 <script>
-    window.updateTooltips = function () {
-        $('[data-toggle="tooltip"]').tooltip();
+    window.updateTooltips = function (elem) {
+        $(elem).tooltip();
     };
 </script>


### PR DESCRIPTION
A very slight perf/encapsulation tweak.

Rather than scanning the whole DOM each time a `<FatalErrorEntry>` is rendered, this PR captures a reference to the inserted DOM element and passes that reference to the JS code. It also avoids the need to rely on synchronous interop, so this would work with server-side execution too.